### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,8 +140,8 @@ https://blogs.msdn.microsoft.com/vcblog/2017/04/11/linux-development-with-c-in-v
     `Boost 1.67.0`  
 `Cpp-netlib 0.13.rc1`  
 `protobuf 3.5.1`  
-`zeromq 3.2.5`  
-`zeromqpp 4.2.0`  
+`libzmq5 4.1.4-7`  
+`zmqpp 3.2.0`  
 `log4cxx - master`  
 `Cryptopp 7.0.0`  
 


### PR DESCRIPTION
In the readme.md file,
the version of `zeromqpp 4.2.0` in the readme.md file should be:
    `zmqpp 3.2.0`
the version of `zeromq 3.2.5` in the readme.md file should be:
    `libzmq5 4.1.4-7`

Both of these package versions come straight from Ubuntu xenial (code name for 16) repositories as defined in the file /etc/apt/sources.list