### PR TITLE
[CRB-110] Rework futures and eliminate undefined behavior

### DIFF
--- a/PoW/Dockerfile
+++ b/PoW/Dockerfile
@@ -42,6 +42,7 @@ COPY hotfix/component_handlers.py  /usr/lib/python3/dist-packages/sawtooth_valid
 COPY hotfix/consensus.py           /usr/lib/python3/dist-packages/sawtooth_validator/journal/consensus/consensus.py
 COPY hotfix/core.py                /usr/lib/python3/dist-packages/sawtooth_validator/server/core.py
 COPY hotfix/executor.py            /usr/lib/python3/dist-packages/sawtooth_validator/execution/executor.py
+COPY hotfix/future.py              /usr/lib/python3/dist-packages/sawtooth_validator/networking/future.py
 COPY hotfix/genesis.py             /usr/lib/python3/dist-packages/sawtooth_validator/journal/genesis.py
 COPY hotfix/gossip.py              /usr/lib/python3/dist-packages/sawtooth_validator/gossip/gossip.py
 COPY hotfix/gossip_handlers.py     /usr/lib/python3/dist-packages/sawtooth_validator/gossip/gossip_handlers.py

--- a/PoW/hotfix/future.py
+++ b/PoW/hotfix/future.py
@@ -1,0 +1,127 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+from threading import Condition
+from threading import RLock
+import time
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FutureResult(object):
+    def __init__(self, message_type, content, connection_id=None):
+        self.message_type = message_type
+        self.content = content
+        self.connection_id = connection_id
+
+
+class FutureTimeoutError(Exception):
+    pass
+
+
+class Future(object):
+    def __init__(self, correlation_id, request=None, callback=None,
+                 timer_ctx=None):
+        self.correlation_id = correlation_id
+        self._request = request
+        self._result = None
+        self._condition = Condition()
+        self._create_time = time.time()
+        self._callback_func = callback
+        self._reconcile_time = None
+        self._timer_ctx = timer_ctx
+
+    def done(self):
+        return self._result is not None
+
+    @property
+    def request(self):
+        return self._request
+
+    def result(self, timeout=None):
+        with self._condition:
+            if self._result is None:
+                if not self._condition.wait(timeout):
+                    raise FutureTimeoutError('Future timed out')
+        return self._result
+
+    def set_result(self, result):
+        with self._condition:
+            self._reconcile_time = time.time()
+            self._result = result
+            self._condition.notify()
+
+    def run_callback(self):
+        """Calls the callback_func, passing in the two positional arguments,
+        conditionally waiting if the callback function hasn't been set yet.
+        Meant to be run in a threadpool owned by the FutureCollection.
+
+        Returns:
+            None
+        """
+
+        if self._callback_func is not None:
+            try:
+                self._callback_func(self._request, self._result)
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception('An unhandled error occurred while running '
+                                 'future callback')
+
+    def get_duration(self):
+        return self._reconcile_time - self._create_time
+
+    def timer_stop(self):
+        if self._timer_ctx:
+            self._timer_ctx.stop()
+        self._timer_ctx = None
+
+
+class FutureCollectionKeyError(Exception):
+    pass
+
+
+class FutureCollection(object):
+    def __init__(self, resolving_threadpool=None):
+        self._futures = {}
+        self._lock = RLock()
+        self._resolving_threadpool = resolving_threadpool
+
+    def put(self, future):
+        self._futures[future.correlation_id] = future
+
+    def set_result(self, correlation_id, result):
+        with self._lock:
+            future = self.get(correlation_id)
+            future.set_result(result)
+            if self._resolving_threadpool is not None:
+                self._resolving_threadpool.submit(future.run_callback)
+            else:
+                future.run_callback()
+
+    def get(self, correlation_id):
+        try:
+            return self._futures[correlation_id]
+        except KeyError:
+            raise FutureCollectionKeyError(
+                "no such correlation id: {}".format(correlation_id))
+
+    def remove(self, correlation_id):
+        try:
+            del self._futures[correlation_id]
+        except KeyError:
+            raise FutureCollectionKeyError(
+                "no such correlation id: {}".format(correlation_id))

--- a/PoW/hotfix/future.py
+++ b/PoW/hotfix/future.py
@@ -52,7 +52,7 @@ class FutureWrapper(object):
         return self._request
 
     def result(self, timeout=None):
-        self._future.result(timeout=timeout)
+        return self._future.result(timeout=timeout)
 
     def set_result(self, result):
         if self._callback:

--- a/PoW/hotfix/future.py
+++ b/PoW/hotfix/future.py
@@ -101,7 +101,8 @@ class FutureCollection(object):
         self._resolving_threadpool = resolving_threadpool
 
     def put(self, future):
-        self._futures[future.correlation_id] = future
+        with self._lock:
+            self._futures[future.correlation_id] = future
 
     def set_result(self, correlation_id, result):
         with self._lock:
@@ -113,15 +114,17 @@ class FutureCollection(object):
                 future.run_callback()
 
     def get(self, correlation_id):
-        try:
-            return self._futures[correlation_id]
-        except KeyError:
-            raise FutureCollectionKeyError(
-                "no such correlation id: {}".format(correlation_id))
+        with self._lock:
+            try:
+                return self._futures[correlation_id]
+            except KeyError:
+                raise FutureCollectionKeyError(
+                    "no such correlation id: {}".format(correlation_id))
 
     def remove(self, correlation_id):
-        try:
-            del self._futures[correlation_id]
-        except KeyError:
-            raise FutureCollectionKeyError(
-                "no such correlation id: {}".format(correlation_id))
+        with self._lock:
+            try:
+                del self._futures[correlation_id]
+            except KeyError:
+                raise FutureCollectionKeyError(
+                    "no such correlation id: {}".format(correlation_id))

--- a/PoW/hotfix/future.py
+++ b/PoW/hotfix/future.py
@@ -35,7 +35,7 @@ class FutureTimeoutError(Exception):
 
 class FutureWrapper(object):
     def __init__(self, correlation_id, request=None, callback=None, loop=None):
-        self._future = loop.create_future() # type: Future
+        self._future = loop.create_future() if loop else Future() # type: Future
         self._event_loop = loop # type : AbstractEventLoop
         self.correlation_id = correlation_id
         self._request = request

--- a/PoW/hotfix/interconnect.py
+++ b/PoW/hotfix/interconnect.py
@@ -243,9 +243,10 @@ class _SendReceive(object):
                     content=b'',
                     message_type=validator_pb2.Message.PING_REQUEST
                 )
-                fut = future.Future(
+                fut = future.FutureWrapper(
                     message.correlation_id,
                     message.content,
+                    loop=self._event_loop,
                 )
                 self._futures.put(fut)
                 message_frame = [
@@ -459,10 +460,12 @@ class _SendReceive(object):
                 connection_info.connection.stop()
 
         self._ready.wait()
+
         fut = future.FutureWrapper(
             msg.correlation_id,
             msg.content,
-            callback)
+            callback, loop=self._event_loop)
+
         if not one_way:
             self._futures.put(fut)
 

--- a/PoW/hotfix/interconnect.py
+++ b/PoW/hotfix/interconnect.py
@@ -535,10 +535,10 @@ class _SendReceive(object):
             self._dispatcher.add_send_last_message(self._connection,
                                                    self.send_last_message)
 
-            asyncio.ensure_future(self._receive_message(),
+            asyncio.run_coroutine_threadsafe(self._receive_message(),
                                 loop=self._event_loop)
 
-            asyncio.ensure_future(self._dispatch_message(),
+            asyncio.run_coroutine_threadsafe(self._dispatch_message(),
                                 loop=self._event_loop)
 
             self._dispatcher_queue = asyncio.Queue()
@@ -549,7 +549,7 @@ class _SendReceive(object):
                 self._monitor_sock = self._socket.get_monitor_socket(
                     zmq.EVENT_DISCONNECTED,
                     addr=self._monitor_fd)
-                asyncio.ensure_future(self._monitor_disconnects(),
+                asyncio.run_coroutine_threadsafe(self._monitor_disconnects(),
                                     loop=self._event_loop)
 
         except Exception as e:
@@ -559,12 +559,12 @@ class _SendReceive(object):
             raise
 
         if self._heartbeat:
-            asyncio.ensure_future(self._do_heartbeat(), loop=self._event_loop)
+            asyncio.run_coroutine_threadsafe(self._do_heartbeat(), loop=self._event_loop)
 
         # Put a 'complete with the setup tasks' sentinel on the queue.
         complete_or_error_queue.put_nowait(_STARTUP_COMPLETE_SENTINEL)
 
-        asyncio.ensure_future(self._notify_started(), loop=self._event_loop)
+        asyncio.run_coroutine_threadsafe(self._notify_started(), loop=self._event_loop)
 
         self._event_loop.run_forever()
         # event_loop.stop called elsewhere will cause the loop to break out

--- a/PoW/hotfix/interconnect.py
+++ b/PoW/hotfix/interconnect.py
@@ -613,7 +613,6 @@ class _SendReceive(object):
         self._event_loop.stop()
 
     def _get_tasks_for_cancelling(self):
-        self._stopping = True
         while True:
             try:
                 tasks = list(asyncio.Task.all_tasks(self._event_loop).copy())
@@ -639,6 +638,7 @@ class _SendReceive(object):
         try:
             acquired = self._shutdown_lock.acquire(blocking=False)
             if acquired and not self._stopping:
+                self._stopping = True
                 self._dispatcher.remove_send_message(self._connection)
                 self._dispatcher.remove_send_last_message(self._connection)
                 if not self._event_loop:

--- a/PoW/hotfix/interconnect.py
+++ b/PoW/hotfix/interconnect.py
@@ -1087,10 +1087,10 @@ class Interconnect(object):
             raise err
 
     def stop(self):
+        self._future_callback_threadpool.shutdown(wait=True)
         self._send_receive_thread.shutdown()
         for conn in self.outbound_connections.values():
             conn.stop()
-        self._future_callback_threadpool.shutdown(wait=True)
 
     def get_connection_id_by_endpoint(self, endpoint):
         """Returns the connection id associated with a publically


### PR DESCRIPTION
The interaction between the callback threadpool and asyncio event loop had issues, including the usage of non-threadsafe asyncio methods, unsynchronized shutdown of the send/receiver (multiple threads could race to shutdown, potentially creating an inconsistent state), the `FutureCollection` class was not consistently synchronized, and the callback threadpool was allowed to live beyond the event loop. This is undefined behavior, as currently executing callbacks could have the event loop taken out from under them - leading to garbage data and nondeterminism - as tasks/futures do not hold a strong reference to their event loop.

This also simplifies the handling of futures by using standard library/asyncio functionality where possible, instead of manual bookkeeping and synchronization.