### PR TITLE
[CRB-110] Fix "Event loop is closed" errors, cleanup interconnect

### DIFF
--- a/PoW/hotfix/future.py
+++ b/PoW/hotfix/future.py
@@ -35,7 +35,7 @@ class FutureTimeoutError(Exception):
 
 class FutureWrapper(object):
     def __init__(self, correlation_id, request=None, callback=None, loop=None):
-        self._future = loop.create_future() if loop else Future() # type: Future
+        self._future = Future() # type: Future
         self._event_loop = loop # type : AbstractEventLoop
         self.correlation_id = correlation_id
         self._request = request

--- a/PoW/hotfix/interconnect.py
+++ b/PoW/hotfix/interconnect.py
@@ -568,6 +568,7 @@ class _SendReceive(object):
         self._event_loop.run_forever()
         # event_loop.stop called elsewhere will cause the loop to break out
         # of run_forever then it can be closed and the context destroyed.
+        self._executor.shutdown(wait=True)
         self._event_loop.close()
         self._socket.close(linger=0)
         if self._monitor:

--- a/PoW/hotfix/interconnect.py
+++ b/PoW/hotfix/interconnect.py
@@ -345,11 +345,11 @@ class _SendReceive(object):
                     zmq_identity, msg_bytes = \
                         await self._socket.recv_multipart()
                     self._received_from_identity(zmq_identity)
-                    await self._dispatch_message(zmq_identity, msg_bytes)
+                    asyncio.ensure_future(self._dispatch_message(zmq_identity, msg_bytes))
                 else:
                     msg_bytes = await self._socket.recv()
                     self._last_message_time = time.time()
-                    await self._dispatch_message(None, msg_bytes)
+                    asyncio.ensure_future(self._dispatch_message(None, msg_bytes))
 
             except CancelledError:
                 # The concurrent.futures.CancelledError is caught by asyncio


### PR DESCRIPTION
Two changes here:

1. Wait for tasks running in the threadpool to exit before closing the event loop. This should fix the errors about the event loop being closed.
2. Remove the queue used between receiving and dispatching a message. Previously we had two separate tasks running on the same thread, with a queue to communicate between them. After receiving a message, we'd put the message bytes on the queue, then in the dispatch task we'd read off the queue, parse the message, then handle it. This is wasteful because the message handling is fairly trivial, so the cost of reading/writing the message twice and going through the concurrent queue is not worth it.