### PR TITLE
get rid of pointless warning

### DIFF
--- a/PoW/hotfix/cli.py
+++ b/PoW/hotfix/cli.py
@@ -324,12 +324,6 @@ def main(args=None):
     if "tcp://" not in bind_component:
         bind_component = "tcp://" + bind_component
 
-    if validator_config.network_public_key is None or \
-            validator_config.network_private_key is None:
-        LOGGER.warning("Network key pair is not configured, Network "
-                       "communications between validators will not be "
-                       "authenticated or encrypted.")
-
     wrapped_registry = None
     metrics_reporter = None
     if validator_config.opentsdb_url:


### PR DESCRIPTION
dlwlalsggg said it best on https://community.creditcoin.org/t/how-to-check-mining-progress/405
> I don’t know why the creditcoin team didn’t remove that warning message.
> However, that warning does not cause any problems with mining.

i'm trying to fix your mistakes haha